### PR TITLE
Background jobs: set queue priorities

### DIFF
--- a/app/jobs/bulk_action_revert_document_job.rb
+++ b/app/jobs/bulk_action_revert_document_job.rb
@@ -2,7 +2,7 @@
 
 # BulkActionRevertDocumentJob
 class BulkActionRevertDocumentJob < ApplicationJob
-  queue_as :default
+  queue_as :priority
 
   def perform(action, doc)
     case action

--- a/app/jobs/bulk_action_revert_job.rb
+++ b/app/jobs/bulk_action_revert_job.rb
@@ -2,7 +2,7 @@
 
 # BulkActionRevertJob
 class BulkActionRevertJob < ApplicationJob
-  queue_as :default
+  queue_as :priority
 
   def perform(bulk_action)
     action = case bulk_action.field_name

--- a/app/jobs/bulk_action_run_document_job.rb
+++ b/app/jobs/bulk_action_run_document_job.rb
@@ -2,7 +2,7 @@
 
 # BulkActionRunDocumentJob
 class BulkActionRunDocumentJob < ApplicationJob
-  queue_as :default
+  queue_as :priority
 
   def perform(action, doc, field_name, field_value)
     case action

--- a/app/jobs/bulk_action_run_job.rb
+++ b/app/jobs/bulk_action_run_job.rb
@@ -2,7 +2,7 @@
 
 # BulkActionRunJob
 class BulkActionRunJob < ApplicationJob
-  queue_as :default
+  queue_as :priority
 
   def perform(bulk_action)
     action = case bulk_action.field_name

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -4,7 +4,7 @@ require "csv"
 
 # ExportJob
 class ExportJob < ApplicationJob
-  queue_as :default
+  queue_as :priority
 
   def perform(request, current_user, query_params, export_service)
     logger.debug("\n\n Background Job: ♞")

--- a/app/jobs/export_json_bulk_job.rb
+++ b/app/jobs/export_json_bulk_job.rb
@@ -4,7 +4,7 @@ require "csv"
 
 # ExportJsonBulkJob
 class ExportJsonBulkJob < ApplicationJob
-  queue_as :default
+  queue_as :priority
 
   def perform(request, current_user, query_params, export_service)
     logger.debug("\n\n Background Job: ♞")

--- a/app/jobs/export_json_job.rb
+++ b/app/jobs/export_json_job.rb
@@ -5,7 +5,7 @@ require "pathname"
 
 # ExportJsonJob
 class ExportJsonJob < ApplicationJob
-  queue_as :default
+  queue_as :priority
 
   def perform(request, current_user, query_params, export_service)
     logger.debug("\n\n Background Job: ♞")

--- a/app/jobs/import_document_job.rb
+++ b/app/jobs/import_document_job.rb
@@ -2,7 +2,7 @@
 
 # ImportDocumentJob class
 class ImportDocumentJob < ApplicationJob
-  queue_as :default
+  queue_as :priority
 
   def perform(import_document)
     # @TODO: Check for friendlier_id or raise error

--- a/app/jobs/import_run_job.rb
+++ b/app/jobs/import_run_job.rb
@@ -2,7 +2,7 @@
 
 # ImportRunJob class
 class ImportRunJob < ApplicationJob
-  queue_as :default
+  queue_as :priority
 
   def perform(import)
     data = CSV.parse(import.csv_file.download.force_encoding("UTF-8"), headers: true)

--- a/app/models/blacklight_api_ids.rb
+++ b/app/models/blacklight_api_ids.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "httparty"
+
 # BlacklightApi
 class BlacklightApiIds
   include HTTParty

--- a/app/views/admin/documents/_result_selected_options.html.erb
+++ b/app/views/admin/documents/_result_selected_options.html.erb
@@ -1,4 +1,4 @@
-<span id="result-selected-options" class="hidden" data-scope="pageset" data-controller="results" data-resultset="<%= admin_documents_path( params.to_unsafe_h.merge({rows: '10000'})) %>" data-pageset="/fetch?">
+<span id="result-selected-options" class="hidden" data-scope="pageset" data-controller="results" data-resultset="<%= admin_documents_path( params.to_unsafe_h.merge({rows: '1000'})) %>" data-pageset="/fetch?">
 
   <%= form_with(model: BulkAction.new, html: { id: 'result-action-form', data: { type: "html", action: "submit->results#setPubState" }, style: 'display:inline'}, url: admin_bulk_actions_path) do |form| -%>
     <%= form.hidden_field :request, value: "#{request.protocol}#{request.host}:#{request.port}" %>

--- a/lib/generators/geoblacklight_admin/config_generator.rb
+++ b/lib/generators/geoblacklight_admin/config_generator.rb
@@ -9,9 +9,10 @@ module GeoblacklightAdmin
     desc <<-DESCRIPTION
       This generator makes the following changes to your application:
        1. Copies GBL Admin initializer files to host config
-       5. Copies database.yml connection to host config
-       5. Copies settings.yml to host config
-       6. Copies .env.development and .env.test to host
+       2. Copies database.yml connection to host config
+       3. Copies sidekiq.yml connection to host config
+       4. Copies settings.yml to host config
+       5. Copies .env.development and .env.test to host
        6. Copies JSON Schema to host
        7. Copies solr/* to host
        8. Sets Routes
@@ -36,6 +37,10 @@ module GeoblacklightAdmin
 
     def create_database_yml
       copy_file "config/database.yml", "config/database.yml", force: true
+    end
+
+    def create_sidekiq_yml
+      copy_file "config/sidekiq.yml", "config/sidekiq.yml", force: true
     end
 
     def create_dotenv

--- a/lib/generators/geoblacklight_admin/templates/config/sidekiq.yml
+++ b/lib/generators/geoblacklight_admin/templates/config/sidekiq.yml
@@ -2,5 +2,6 @@
 :max_retries: 1
 
 :queues:
-  - priority
+  - [priority, 2]
+  - [devise, 1]
   - default

--- a/lib/generators/geoblacklight_admin/templates/config/sidekiq.yml
+++ b/lib/generators/geoblacklight_admin/templates/config/sidekiq.yml
@@ -2,6 +2,6 @@
 :max_retries: 1
 
 :queues:
-  - [priority, 2]
-  - [devise, 1]
+  - priority
+  - devise
   - default

--- a/lib/generators/geoblacklight_admin/templates/config/sidekiq.yml
+++ b/lib/generators/geoblacklight_admin/templates/config/sidekiq.yml
@@ -1,0 +1,6 @@
+:concurrency:  3
+:max_retries: 1
+
+:queues:
+  - priority
+  - default


### PR DESCRIPTION
Fixes #22 

Import and export jobs are critical to workflow productivity. We need to move these jobs into a prioritized queue, so long running background jobs (like thumbnail harvesting or URI checking) don't back up the queue of important GBL Admin work.

New queue is named "priority". Configuration requires sidekiq to clear the "priority" queue before returning to work on default queue jobs.

Also, dropping the default row pagination count for export jobs, which is helpful for the BTAA Geoportal's currently undersized web servers.