### PR TITLE
Document: current_version should always return a value

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -192,7 +192,8 @@ class Document < Kithe::Work
   end
 
   def current_version
-    versions.last.index
+    # Will return 0 if no PaperTrail version exists yet
+    versions&.last&.index || 0
   end
 
   # Institutional Access URLs


### PR DESCRIPTION
If you have any documents in your database that do not have a corresponding PaperTrail version history, they will fail to BulkAction (ex. updating publication_state).

This change always returns a value for document.current_version, so BulkActions will run correctly.