### PR TITLE
Assets: Allow edit parent_id after create

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,5 @@ else
   end
 end
 # END ENGINE_CART BLOCK
+
+gem "rails-controller-testing", "~> 1.0"

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -5,7 +5,7 @@ module Admin
   class AssetsController < Admin::AdminController
     before_action :set_asset, only: %i[show edit update destroy]
 
-    # GET /assets or /assets.json
+    # GET /admin/asset_files
     def index
       scope = Asset
       search_query = params[:q].strip if params[:q].present?
@@ -32,34 +32,14 @@ module Admin
     def show
     end
 
-    # GET /assets/new
-    def new
-      @asset = Asset.new
-    end
-
     # GET /assets/1/edit
     def edit
-    end
-
-    # POST /assets or /assets.json
-    def create
-      @asset = Asset.new(asset_params)
-
-      respond_to do |format|
-        if @asset.save
-          format.html { redirect_to admin_asset_url(@asset), notice: "Asset was successfully created." }
-          format.json { render :show, status: :created, location: @asset }
-        else
-          format.html { render :new, status: :unprocessable_entity }
-          format.json { render json: @asset.errors, status: :unprocessable_entity }
-        end
-      end
     end
 
     # PATCH/PUT /assets/1 or /assets/1.json
     def update
       respond_to do |format|
-        if @asset.update(asset_params)
+        if @asset.update(asset_params.merge!(parent_id: parent_id_via_friendly_id(asset_params[:parent_id])))
           format.html { redirect_to admin_asset_url(@asset.id), notice: "Asset was successfully updated." }
           format.json { render :show, status: :ok, location: @asset }
         else
@@ -116,12 +96,11 @@ module Admin
       redirect_to admin_assets_url, notice: "Files attached successfully."
     end
 
-    def sort
-      Asset.sort_assets(params[:id_list])
-      render body: nil
-    end
-
     private
+
+    def parent_id_via_friendly_id(friendlier_id)
+      Document.find_by_friendlier_id(friendlier_id)&.id
+    end
 
     # Use callbacks to share common setup or constraints between actions.
     def set_asset
@@ -130,7 +109,7 @@ module Admin
 
     # Only allow a list of trusted parameters through.
     def asset_params
-      params.require(:asset)
+      params.require(:asset).permit(:parent_id)
     end
 
     def date_check?(val)

--- a/geoblacklight_admin.gemspec
+++ b/geoblacklight_admin.gemspec
@@ -60,6 +60,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest-ci", "~> 3.4"
   s.add_development_dependency "minitest-rails", "~> 7.0"
   s.add_development_dependency "minitest-reporters", "~> 1.6"
+  s.add_development_dependency "rails-controller-testing", "~> 1.0"
   s.add_development_dependency "rspec-rails", "~> 3.0"
   s.add_development_dependency "selenium-webdriver"
   s.add_development_dependency "shoulda-context", "~> 2.0"

--- a/test/controllers/admin/assets_controller_test.rb
+++ b/test/controllers/admin/assets_controller_test.rb
@@ -5,12 +5,12 @@ require "test_helper"
 module Admin
   class AssetsControllerTest < ActionDispatch::IntegrationTest
     setup do
-      @asset = assets(:asset_1) 
+      @asset = assets(:asset_1)
 
       get "/users/sign_in"
       sign_in_as users(:user_001)
       post user_session_url
-  
+
       follow_redirect!
       assert_response :success
     end

--- a/test/controllers/admin/assets_controller_test.rb
+++ b/test/controllers/admin/assets_controller_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Admin
+  class AssetsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @asset = assets(:asset_1) 
+
+      get "/users/sign_in"
+      sign_in_as users(:user_001)
+      post user_session_url
+  
+      follow_redirect!
+      assert_response :success
+    end
+
+    test "should get index" do
+      get admin_assets_url
+      assert_response :success
+      assert_not_nil assigns(:assets)
+    end
+
+    test "should show asset" do
+      get admin_asset_path(@asset.id)
+      assert_response :success
+    end
+
+    test "should get edit" do
+      get edit_admin_asset_url(@asset.id)
+      assert_response :success
+    end
+
+    test "should update asset" do
+      patch admin_asset_url(@asset.id), params: {asset: {parent_id: @asset.parent_id}}
+      assert_redirected_to admin_asset_url(@asset.id)
+      assert_equal "Asset was successfully updated.", flash[:notice]
+    end
+
+    test "should destroy asset" do
+      assert_difference("Asset.count", -1) do
+        delete admin_asset_url(@asset.id)
+      end
+
+      assert_redirected_to admin_assets_url
+      assert_equal "Asset was successfully destroyed.", flash[:notice]
+    end
+
+    test "should display attach form" do
+      get display_attach_form_admin_assets_url
+      assert_response :success
+    end
+
+    test "should attach files" do
+      skip "Need a image fixture to test this properly"
+      files = ["{\"id\":\"asset/82e5df8e7843b9e0c7a1420ad30b3f56.jpg\",\"storage\":\"cache\",\"metadata\":{\"filename\":\"albertsons_2k.jpg\",\"size\":858270,\"mime_type\":\"image/jpeg\",\"width\":2135,\"height\":2470}}"]
+      post attach_files_admin_assets_url, params: {cached_files: files}
+      assert_redirected_to admin_assets_url
+      assert_equal "Files attached successfully.", flash[:notice]
+    end
+
+    private
+
+    # Set up the necessary data for the tests
+    def setup_data
+      @asset = assets(:asset_1) # Ensure you have appropriate fixtures or factories
+    end
+  end
+end


### PR DESCRIPTION
Friendlier ids and actual database ids are troublesome. Here we need to lookup the actual database id to map an asset to its parent. Removes scaffolded methods not required. Adds some tests for this controller.

Fixes #76