### PR TITLE
Fix Thumbnails Workflow

### DIFF
--- a/app/helpers/geoblacklight_admin_helper.rb
+++ b/app/helpers/geoblacklight_admin_helper.rb
@@ -155,4 +155,36 @@ module GeoblacklightAdminHelper
   def assets_dct_references_options
     escape_javascript(options_for_select(I18n.t("activemodel.enum_values.document/reference.category").invert.sort.insert(0, ["Choose Reference Type", nil]))).to_s
   end
+
+  # Determines if a document's thumbnail should be rendered.
+  #
+  # @param document [Object] the document object
+  # @return [Boolean] true if the thumbnail should be rendered, false otherwise
+  def thumb_to_render?(document)
+    if document&.thumbnail&.file_url&.present? && document&.thumbnail&.file_derivatives&.present?
+      true
+    elsif document&.document_assets&.any?
+      document.document_assets.any? do |asset|
+        asset.file_derivatives&.key?(:thumb_standard_2X)
+      end
+    else
+      false
+    end
+  end
+
+  # Returns the URL of the thumbnail to render for a document.
+  #
+  # @param document [Object] the document object
+  # @return [String] the URL of the thumbnail to render
+  def thumbnail_to_render(document)
+    if document&.thumbnail&.file_url&.present? && document&.thumbnail&.file_derivatives&.present?
+      document.thumbnail.file_url(:thumb_standard_2X)
+    elsif document&.document_assets&.any?
+      document.document_assets.find do |asset|
+        asset.file_derivatives&.key?(:thumb_standard_2X)
+      end&.file_url(:thumb_standard_2X)
+    else
+      nil
+    end
+  end
 end

--- a/app/helpers/geoblacklight_admin_helper.rb
+++ b/app/helpers/geoblacklight_admin_helper.rb
@@ -183,8 +183,6 @@ module GeoblacklightAdminHelper
       document.document_assets.find do |asset|
         asset.file_derivatives&.key?(:thumb_standard_2X)
       end&.file_url(:thumb_standard_2X)
-    else
-      nil
     end
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -38,9 +38,7 @@ class Document < Kithe::Work
   # @TODO: Redundant? Kithe also includes a members association
   def document_assets
     scope = Kithe::Asset
-    scope = scope.where(parent_id: id)
-
-    # scope = scope.page(params[:page]).per(20).order(created_at: :desc)
+    scope = scope.where(parent_id: id).order(position: :asc)
     scope.includes(:parent)
   end
 

--- a/app/views/admin/bulk_actions/show.html.erb
+++ b/app/views/admin/bulk_actions/show.html.erb
@@ -43,7 +43,7 @@
           <% if @bulk_action.state_machine.current_state == 'created' %>
             <%= form_tag run_admin_bulk_action_path(@bulk_action), method: :patch do -%>
               <%= hidden_field_tag :run, true -%>
-              <%= submit_tag 'Run Bulk Action' -%>
+              <%= submit_tag '+ Run Bulk Action', class: 'btn btn-primary btn-block' -%>
             <%- end -%>
           <% else %>
             <%= @bulk_action.state_machine.current_state %>

--- a/app/views/admin/documents/_document.html.erb
+++ b/app/views/admin/documents/_document.html.erb
@@ -8,9 +8,7 @@
         <% @document = Document.find_by(friendlier_id: document.friendlier_id) %>
         <% if thumb_to_render?(@document) %>
           <%= link_to edit_admin_document_path(document.friendlier_id) do %>
-            <% if @document.thumbnail.file_derivatives[:thumb_standard_2X].exists? %>
-              <%= image_tag(@document.thumbnail.file_url(:thumb_standard_2X), class: "thumbnail") %>
-            <% end %>
+            <%= image_tag(thumbnail_to_render(@document), class: "thumbnail") %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/admin/documents/_form.html.erb
+++ b/app/views/admin/documents/_form.html.erb
@@ -8,11 +8,9 @@
           <h1 class="h5">
             <% if @document.persisted? %>
               <div class="row">
-                <% if @document.thumbnail.present? %>
+                <% if thumb_to_render?(@document) %>
                   <div class="thumbnail col-2">
-                    <% unless @document&.thumbnail&.file_url(:thumb_mini).nil? %>
-                      <%= image_tag @document&.thumbnail&.file_url(:thumb_mini) %>
-                    <% end %>
+                    <%= image_tag thumbnail_to_render(@document), class: "thumbnail" %>
                   </div>
                 <% end %>
                 <div class="col">

--- a/test/helpers/geoblacklight_admin_helper_test.rb
+++ b/test/helpers/geoblacklight_admin_helper_test.rb
@@ -3,10 +3,31 @@
 require "test_helper"
 
 class GeoblacklightAdminHelperTest < ActionView::TestCase
+  include GeoblacklightAdminHelper
   attr_reader :current_user
 
   setup do
     @current_user = users(:user_001)
+
+    @document_with_thumbnail = OpenStruct.new(
+      thumbnail: OpenStruct.new(
+        file_url: 'http://example.com/thumbnail.jpg',
+        file_derivatives: { thumb_standard_2X: 'http://example.com/thumbnail_2x.jpg' }
+      ),
+      document_assets: []
+    )
+
+    @document_with_assets = OpenStruct.new(
+      thumbnail: nil,
+      document_assets: [
+        OpenStruct.new(file_derivatives: { thumb_standard_2X: 'http://example.com/asset_thumbnail_2x.jpg' })
+      ]
+    )
+
+    @document_without_thumbnail = OpenStruct.new(
+      thumbnail: nil,
+      document_assets: []
+    )
   end
 
   test "diff_class" do
@@ -71,5 +92,21 @@ class GeoblacklightAdminHelperTest < ActionView::TestCase
 
   test "params_as_hidden_fields" do
     assert_equal "<input type=\"hidden\" name=\"q\" value=\"foo\" autocomplete=\"off\" />", params_as_hidden_fields({"q" => "foo"})
+  end
+
+  test "thumb_to_render_with_thumbnail" do
+    assert thumb_to_render?(@document_with_thumbnail)
+  end
+
+  test "thumb_to_render_with_assets" do
+    assert thumb_to_render?(@document_with_assets)
+  end
+
+  test "thumb_to_render_without_thumbnail_or_assets" do
+    refute thumb_to_render?(@document_without_thumbnail)
+  end
+
+  test "thumbnail_to_render_without_thumbnail_or_assets" do
+    assert_nil thumbnail_to_render(@document_without_thumbnail)
   end
 end

--- a/test/helpers/geoblacklight_admin_helper_test.rb
+++ b/test/helpers/geoblacklight_admin_helper_test.rb
@@ -11,8 +11,8 @@ class GeoblacklightAdminHelperTest < ActionView::TestCase
 
     @document_with_thumbnail = OpenStruct.new(
       thumbnail: OpenStruct.new(
-        file_url: 'http://example.com/thumbnail.jpg',
-        file_derivatives: { thumb_standard_2X: 'http://example.com/thumbnail_2x.jpg' }
+        file_url: "http://example.com/thumbnail.jpg",
+        file_derivatives: {thumb_standard_2X: "http://example.com/thumbnail_2x.jpg"}
       ),
       document_assets: []
     )
@@ -20,7 +20,7 @@ class GeoblacklightAdminHelperTest < ActionView::TestCase
     @document_with_assets = OpenStruct.new(
       thumbnail: nil,
       document_assets: [
-        OpenStruct.new(file_derivatives: { thumb_standard_2X: 'http://example.com/asset_thumbnail_2x.jpg' })
+        OpenStruct.new(file_derivatives: {thumb_standard_2X: "http://example.com/asset_thumbnail_2x.jpg"})
       ]
     )
 


### PR DESCRIPTION
If we've crawled/harvested thumbnails, those thumbs will be the first entry in the document.document_assets relationship and they'll be used by default.

Alternatively, you can upload an Asset, and if image derivatives can be made from that file, those will be the thumbnail.