### PR TITLE
Thumbnails workflow: make it even simpler

### DIFF
--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -109,7 +109,7 @@ module Admin
 
     # Only allow a list of trusted parameters through.
     def asset_params
-      params.require(:asset).permit(:parent_id)
+      params.require(:asset).permit(:parent_id, :thumbnail)
     end
 
     def date_check?(val)

--- a/app/controllers/admin/document_assets_controller.rb
+++ b/app/controllers/admin/document_assets_controller.rb
@@ -126,7 +126,7 @@ module Admin
 
     # Only allow a list of trusted parameters through.
     def document_asset_params
-      params.require(:asset).permit(:title, :label, :dct_references_uri_key)
+      params.require(:asset).permit(:title, :label, :dct_references_uri_key, :thumbnail)
     end
   end
 end

--- a/app/helpers/geoblacklight_admin_helper.rb
+++ b/app/helpers/geoblacklight_admin_helper.rb
@@ -155,4 +155,36 @@ module GeoblacklightAdminHelper
   def assets_dct_references_options
     escape_javascript(options_for_select(I18n.t("activemodel.enum_values.document/reference.category").invert.sort.insert(0, ["Choose Reference Type", nil]))).to_s
   end
+
+  # Determines if a document's thumbnail should be rendered.
+  #
+  # @param document [Object] the document object
+  # @return [Boolean] true if the thumbnail should be rendered, false otherwise
+  def thumb_to_render?(document)
+    if document&.thumbnail&.file_url&.present? && document&.thumbnail&.file_derivatives&.present?
+      true
+    elsif document&.document_assets&.any?
+      document.document_assets.any? do |asset|
+        asset.file_derivatives&.key?(:thumb_standard_2X)
+      end
+    else
+      false
+    end
+  end
+
+  # Returns the URL of the thumbnail to render for a document.
+  #
+  # @param document [Object] the document object
+  # @return [String] the URL of the thumbnail to render
+  def thumbnail_to_render(document)
+    if document&.thumbnail&.file_url&.present? && document&.thumbnail&.file_derivatives&.present?
+      document.thumbnail.file_url(:thumb_standard_2X)
+    elsif document&.document_assets&.any?
+      document.document_assets.find do |asset|
+        asset.file_derivatives&.key?(:thumb_standard_2X)
+      end&.file_url(:thumb_standard_2X)
+    else
+      nil
+    end
+  end
 end

--- a/app/helpers/geoblacklight_admin_helper.rb
+++ b/app/helpers/geoblacklight_admin_helper.rb
@@ -183,8 +183,6 @@ module GeoblacklightAdminHelper
       document.document_assets.find do |asset|
         asset.file_derivatives&.key?(:thumb_standard_2X)
       end&.file_url(:thumb_standard_2X)
-    else
-      nil
     end
   end
 end

--- a/app/javascript/controllers/results_controller.js
+++ b/app/javascript/controllers/results_controller.js
@@ -12,6 +12,7 @@ import { Controller } from "stimulus"
 export default class extends Controller {
 
   connect() {
+    console.log("GBL Admin - ResultsController connected");
   }
 
   checkedState(checked, selector='input[type=checkbox]') {

--- a/app/javascript/entrypoints/engine.js
+++ b/app/javascript/entrypoints/engine.js
@@ -1,8 +1,0 @@
-console.log('Vite ⚡️ Rails - GBL Admin')
-
-// Stimulus
-import { Application } from '@hotwired/stimulus'
-import ResultsController from "../controllers/results_controller"
-
-window.Stimulus = Application.start()
-Stimulus.register("results", ResultsController)

--- a/app/javascript/index.js
+++ b/app/javascript/index.js
@@ -1,8 +1,11 @@
 console.log('Vite ⚡️ Rails - GBL Admin')
 
-// Stimulus
+// Import Stimulus and controllers
 import { Application } from '@hotwired/stimulus'
 import ResultsController from "./controllers/results_controller"
 
+// Initialize Stimulus
 window.Stimulus = Application.start()
+
+// Register controllers
 Stimulus.register("results", ResultsController)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -38,9 +38,7 @@ class Document < Kithe::Work
   # @TODO: Redundant? Kithe also includes a members association
   def document_assets
     scope = Kithe::Asset
-    scope = scope.where(parent_id: id)
-
-    # scope = scope.page(params[:page]).per(20).order(created_at: :desc)
+    scope = scope.where(parent_id: id).order(position: :asc)
     scope.includes(:parent)
   end
 

--- a/app/views/admin/bulk_actions/show.html.erb
+++ b/app/views/admin/bulk_actions/show.html.erb
@@ -43,7 +43,7 @@
           <% if @bulk_action.state_machine.current_state == 'created' %>
             <%= form_tag run_admin_bulk_action_path(@bulk_action), method: :patch do -%>
               <%= hidden_field_tag :run, true -%>
-              <%= submit_tag 'Run Bulk Action' -%>
+              <%= submit_tag '+ Run Bulk Action', class: 'btn btn-primary btn-block' -%>
             <%- end -%>
           <% else %>
             <%= @bulk_action.state_machine.current_state %>

--- a/app/views/admin/document_assets/index.html.erb
+++ b/app/views/admin/document_assets/index.html.erb
@@ -47,8 +47,9 @@
           <% @document_assets.each do |document_asset| %>
             <tr>
               <td>
-                <% if document_asset.respond_to?(:thumbnail) %>
-                  <%= document_asset.thumbnail %> 
+                <%= form_with model: document_asset, url: admin_document_document_asset_path(document_asset.parent, document_asset), method: :put, remote: true, class: 'thumbnail-form' do |f| %>
+                  <%= f.check_box :thumbnail, class: 'thumbnail-toggle', onchange: "this.form.submit()" %>
+                  <%= f.submit 'Save', class: 'btn btn-sm btn-primary d-none' %>
                 <% end %>
               </td>
               <td>

--- a/app/views/admin/documents/_document.html.erb
+++ b/app/views/admin/documents/_document.html.erb
@@ -8,9 +8,7 @@
         <% @document = Document.find_by(friendlier_id: document.friendlier_id) %>
         <% if thumb_to_render?(@document) %>
           <%= link_to edit_admin_document_path(document.friendlier_id) do %>
-            <% if @document.thumbnail.file_derivatives[:thumb_standard_2X].exists? %>
-              <%= image_tag(@document.thumbnail.file_url(:thumb_standard_2X), class: "thumbnail") %>
-            <% end %>
+            <%= image_tag(thumbnail_to_render(@document), class: "thumbnail") %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/admin/documents/_form.html.erb
+++ b/app/views/admin/documents/_form.html.erb
@@ -8,11 +8,9 @@
           <h1 class="h5">
             <% if @document.persisted? %>
               <div class="row">
-                <% if @document.thumbnail.present? %>
+                <% if thumb_to_render?(@document) %>
                   <div class="thumbnail col-2">
-                    <% unless @document&.thumbnail&.file_url(:thumb_mini).nil? %>
-                      <%= image_tag @document&.thumbnail&.file_url(:thumb_mini) %>
-                    <% end %>
+                    <%= image_tag thumbnail_to_render(@document), class: "thumbnail" %>
                   </div>
                 <% end %>
                 <div class="col">

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,3 +20,11 @@ standardrb --fix
 ```bash
 bundle exec rake ci
 ```
+
+### Build Node Module
+Bump the package version in `package.json` and run the following commands to build and publish the node module.
+
+```bash
+bundle exec vite build
+npm publish
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@geoblacklight/admin",
   "type": "module",
-  "version": "0.4.4",
+  "version": "0.4.12",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/test/helpers/geoblacklight_admin_helper_test.rb
+++ b/test/helpers/geoblacklight_admin_helper_test.rb
@@ -3,10 +3,31 @@
 require "test_helper"
 
 class GeoblacklightAdminHelperTest < ActionView::TestCase
+  include GeoblacklightAdminHelper
   attr_reader :current_user
 
   setup do
     @current_user = users(:user_001)
+
+    @document_with_thumbnail = OpenStruct.new(
+      thumbnail: OpenStruct.new(
+        file_url: 'http://example.com/thumbnail.jpg',
+        file_derivatives: { thumb_standard_2X: 'http://example.com/thumbnail_2x.jpg' }
+      ),
+      document_assets: []
+    )
+
+    @document_with_assets = OpenStruct.new(
+      thumbnail: nil,
+      document_assets: [
+        OpenStruct.new(file_derivatives: { thumb_standard_2X: 'http://example.com/asset_thumbnail_2x.jpg' })
+      ]
+    )
+
+    @document_without_thumbnail = OpenStruct.new(
+      thumbnail: nil,
+      document_assets: []
+    )
   end
 
   test "diff_class" do
@@ -71,5 +92,21 @@ class GeoblacklightAdminHelperTest < ActionView::TestCase
 
   test "params_as_hidden_fields" do
     assert_equal "<input type=\"hidden\" name=\"q\" value=\"foo\" autocomplete=\"off\" />", params_as_hidden_fields({"q" => "foo"})
+  end
+
+  test "thumb_to_render_with_thumbnail" do
+    assert thumb_to_render?(@document_with_thumbnail)
+  end
+
+  test "thumb_to_render_with_assets" do
+    assert thumb_to_render?(@document_with_assets)
+  end
+
+  test "thumb_to_render_without_thumbnail_or_assets" do
+    refute thumb_to_render?(@document_without_thumbnail)
+  end
+
+  test "thumbnail_to_render_without_thumbnail_or_assets" do
+    assert_nil thumbnail_to_render(@document_without_thumbnail)
   end
 end

--- a/test/helpers/geoblacklight_admin_helper_test.rb
+++ b/test/helpers/geoblacklight_admin_helper_test.rb
@@ -11,8 +11,8 @@ class GeoblacklightAdminHelperTest < ActionView::TestCase
 
     @document_with_thumbnail = OpenStruct.new(
       thumbnail: OpenStruct.new(
-        file_url: 'http://example.com/thumbnail.jpg',
-        file_derivatives: { thumb_standard_2X: 'http://example.com/thumbnail_2x.jpg' }
+        file_url: "http://example.com/thumbnail.jpg",
+        file_derivatives: {thumb_standard_2X: "http://example.com/thumbnail_2x.jpg"}
       ),
       document_assets: []
     )
@@ -20,7 +20,7 @@ class GeoblacklightAdminHelperTest < ActionView::TestCase
     @document_with_assets = OpenStruct.new(
       thumbnail: nil,
       document_assets: [
-        OpenStruct.new(file_derivatives: { thumb_standard_2X: 'http://example.com/asset_thumbnail_2x.jpg' })
+        OpenStruct.new(file_derivatives: {thumb_standard_2X: "http://example.com/asset_thumbnail_2x.jpg"})
       ]
     )
 


### PR DESCRIPTION
Adds a clear thumbnail attribute checkbox on the assets table. Any asset can be a thumbnail, so the topmost asset with a thumbnail=true attr wins.

![Screenshot 2024-11-05 at 10 12 54 AM](https://github.com/user-attachments/assets/7739aafa-a1bc-4bbe-9315-707ee0836a6d)
