### PR TITLE
Distribution Imports: run in a background queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The gem is available as open source under the terms of the [Apache 2.0 License](
 * ~~Debug Rails 7.2 support (remove devise_invitable, see [#915](https://github.com/scambra/devise_invitable/issues/915))~~
 * ~~Separate dct_references_s support into a separate model~~
 * ~~Import/Export dct_references_s outside of the main document model~~
+* Distributions: Move import to background queue
 * Data Dictionary: Add support for `document_data_dictionary`
 * Gazetteer: Add GeoNames support
 * Gazetteer: Add Who's On First support

--- a/app/controllers/admin/document_distributions_controller.rb
+++ b/app/controllers/admin/document_distributions_controller.rb
@@ -112,44 +112,6 @@ module Admin
       end
     end
 
-    # GET/POST /documents/1/distributions/import
-    #
-    # Imports document distributions from a file. If successful, redirects with a success notice.
-    # Otherwise, redirects with an error notice.
-    def import
-      return if request.get?
-
-      logger.debug("Import Distributions")
-
-      unless params.dig(:document_distribution, :distributions, :file)
-        raise ArgumentError, "File does not exist or is invalid."
-      end
-
-      success, errors = DocumentDistribution.import(params.dig(:document_distribution, :distributions, :file))
-      if success == true
-        logger.debug("Distributions were created successfully.")
-        if params[:document_id]
-          redirect_to admin_document_document_distributions_path(@document), notice: "Distributions were created successfully."
-        else
-          redirect_to admin_document_distributions_path, notice: "Distributions were created successfully."
-        end
-      else
-        logger.debug("Some distributions could not be created. #{errors.join(", ")}")
-        if params[:document_id]
-          redirect_to admin_document_document_distributions_path(@document), notice: "Some distributions could not be created. #{errors.join(", ")}"
-        else
-          redirect_to admin_document_distributions_path, notice: "Some distributions could not be created. #{errors.join(", ")}"
-        end
-      end
-    rescue => e
-      logger.debug("Distributions could not be created. #{e}")
-      if params[:document_id]
-        redirect_to admin_document_document_distributions_path(@document), notice: "Distributions could not be created. #{e}"
-      else
-        redirect_to admin_document_distributions_path, notice: "Distributions could not be created. #{e}"
-      end
-    end
-
     private
 
     # Sets the document based on the document_id parameter.

--- a/app/controllers/admin/import_distributions_controller.rb
+++ b/app/controllers/admin/import_distributions_controller.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+# Admin::ImportDistributionsController
+#
+# This controller handles the CRUD operations for ImportDistribution objects within the admin namespace.
+# It provides actions to list, show, create, update, and delete import distributions, as well as run an import distribution.
+#
+# Before Actions:
+# - set_import_distribution: Sets the @import_distribution instance variable for actions that require an import distribution ID.
+#
+# Actions:
+# - index: Lists all imports with pagination.
+# - show: Displays a specific import and its associated documents, with pagination for success and failed states.
+# - new: Initializes a new Import object.
+# - edit: Prepares an existing Import object for editing.
+# - create: Creates a new Import object and redirects to import mappings if successful.
+# - update: Updates an existing Import object and redirects to the import if successful.
+# - destroy: Deletes an Import object and redirects to the imports list.
+# - run: Executes the import process and redirects to the import show page.
+#
+# Private Methods:
+# - set_import: Finds and sets the import based on the provided ID.
+# - permittable_params: Returns an array of permitted parameters for import.
+# - import_params: Permits parameters for creating or updating an import, including nested attributes.
+module Admin
+  class ImportDistributionsController < Admin::AdminController
+    before_action :set_import_distribution, only: %i[show edit update destroy run]
+
+    # GET /import_distributions
+    # GET /import_distributions.json
+    # Lists all import distributions with pagination.
+    def index
+      @pagy, @import_distributions = pagy(ImportDistribution.all.order("created_at DESC"), items: 20)
+    end
+
+    # GET /import_distributions/1
+    # GET /import_distributions/1.json
+    # Displays a specific import distribution and its associated documents, with pagination for success and failed states.
+    def show
+      @pagy_failed, @import_failed_distributions = pagy(@import_distribution.import_document_distributions.not_in_state(:success), items: 50, page_param: :failed_page)
+      @pagy_success, @import_success_distributions = pagy(@import_distribution.import_document_distributions.in_state(:success), items: 50, page_param: :success_page)
+    end
+
+    # GET /import_distributions/new
+    # Initializes a new ImportDistribution object.
+    def new
+      @import_distribution = ImportDistribution.new
+    end
+
+    # GET /import_distributions/1/edit
+    # Prepares an existing ImportDistribution object for editing.
+    def edit
+    end
+
+    # POST /import_distributions
+    # POST /import_distributions.json
+    # Creates a new ImportDistribution object and redirects to import mappings if successful.
+    def create
+      @import_distribution = ImportDistribution.new(import_distribution_params)
+
+      respond_to do |format|
+        if @import_distribution.save
+          format.html do
+            redirect_to admin_import_distribution_path(@import_distribution),
+              notice: "Import distribution was successful. Please set your import distribution mapping rules."
+          end
+          format.json { render :show, status: :created, location: @import_distribution }
+        else
+          format.html { render :new, status: :unprocessable_entity }
+          format.json { render json: @import_distribution.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+
+    # PATCH/PUT /import_distributions/1
+    # PATCH/PUT /import_distributions/1.json
+    # Updates an existing ImportDistribution object and redirects to the import distribution if successful.
+    def update
+      respond_to do |format|
+        if @import_distribution.update(import_distribution_params)
+          format.html { redirect_to admin_import_distribution_path(@import_distribution), notice: "Import distribution was successfully updated." }
+          format.json { render :show, status: :ok, location: @import_distribution }
+        else
+          format.html { render :edit, status: :unprocessable_entity }
+          format.json { render json: @import_distribution.errors, status: :unprocessable_entity }
+        end
+      end
+    end
+
+    # DELETE /import_distributions/1
+    # DELETE /import_distributions/1.json
+    # Deletes an ImportDistribution object and redirects to the import distributions list.
+    def destroy
+      @import_distribution.destroy
+      respond_to do |format|
+        format.html { redirect_to admin_import_distributions_url, notice: "Import distribution was successfully destroyed." }
+        format.json { head :no_content }
+      end
+    end
+
+    # Runs the import process and redirects to the import show page.
+    def run
+      @import_distribution.run!
+      redirect_to admin_import_distribution_url(@import_distribution), notice: "Import distribution is running. Check back soon for results."
+    end
+
+    private
+
+    # Use callbacks to share common setup or constraints between actions.
+    # Finds and sets the import distribution based on the provided ID.
+    def set_import_distribution
+      @import_distribution = ImportDistribution.find(params[:id])
+    end
+
+    # Returns an array of permitted parameters for import distribution.
+    def permittable_params
+      %i[name filename source description row_count encoding content_type extension validity validation_result
+        csv_file run]
+    end
+
+    # Permits parameters for creating or updating an import distribution, including nested attributes.
+    def import_distribution_params
+      params.require(:import_distribution).permit(permittable_params)
+    end
+  end
+end

--- a/app/controllers/admin/import_distributions_controller.rb
+++ b/app/controllers/admin/import_distributions_controller.rb
@@ -54,7 +54,7 @@ module Admin
 
     # POST /import_distributions
     # POST /import_distributions.json
-    # Creates a new ImportDistribution object and redirects to import mappings if successful.
+    # Creates a new ImportDistribution object
     def create
       @import_distribution = ImportDistribution.new(import_distribution_params)
 
@@ -62,7 +62,7 @@ module Admin
         if @import_distribution.save
           format.html do
             redirect_to admin_import_distribution_path(@import_distribution),
-              notice: "Import distribution was successful. Please set your import distribution mapping rules."
+              notice: "Import distribution was successful."
           end
           format.json { render :show, status: :created, location: @import_distribution }
         else

--- a/app/jobs/import_distributions_run_job.rb
+++ b/app/jobs/import_distributions_run_job.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# ImportDistributionsRunJob class
+class ImportDistributionsRunJob < ApplicationJob
+  queue_as :priority
+
+  def perform(import)
+    data = CSV.parse(import.csv_file.download, headers: true)
+
+    data.each do |dist|
+      extract_hash = dist.to_h
+
+      document_distribution_hash = {
+        friendlier_id: extract_hash["friendlier_id"],
+        reference_type: extract_hash["reference_type"],
+        distribution_url: extract_hash["distribution_url"],
+        label: extract_hash["label"],
+        import_distribution_id: import.id
+      }
+
+      # Capture document distribution for import attempt
+      import_document_distribution = ImportDocumentDistribution.create(document_distribution_hash)
+
+      # Add import document distribution to background job queue
+      ImportDocumentDistributionJob.perform_later(import_document_distribution)
+    rescue => e
+      logger.debug "\n\nCANNOT IMPORT DISTRIBUTION: #{extract_hash.inspect}"
+      logger.debug "Error: #{e.inspect}\n\n"
+      next
+    end
+  end
+end

--- a/app/jobs/import_document_distribution_job.rb
+++ b/app/jobs/import_document_distribution_job.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# ImportDocumentDistributionJob class
+class ImportDocumentDistributionJob < ApplicationJob
+  queue_as :priority
+
+  def perform(import_document_distribution)
+    document_distribution = DocumentDistribution.find_or_create_by(
+      friendlier_id: import_document_distribution.friendlier_id,
+      reference_type: ReferenceType.find_by(name: import_document_distribution.reference_type),
+      url: import_document_distribution.distribution_url
+    )
+
+    if document_distribution.update(import_document_distribution.to_hash)
+      import_document_distribution.state_machine.transition_to!(:success)
+    else
+      import_document_distribution.state_machine.transition_to!(:failed, "Failed - #{document_distribution.errors.inspect}")
+    end
+  rescue => e
+    logger.debug("Error: #{e}")
+    import_document_distribution.state_machine.transition_to!(:failed, "Error - #{e.inspect}")
+  end
+end

--- a/app/models/import_distribution.rb
+++ b/app/models/import_distribution.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "csv"
+
+# ImportDistribution class
+class ImportDistribution < ApplicationRecord
+  include ActiveModel::Validations
+
+  # Callbacks (keep at top)
+  after_commit :set_csv_file_attributes, if: :persisted?
+
+  # Associations
+  has_one_attached :csv_file
+  has_many :document_distributions, dependent: :destroy
+  has_many :import_document_distributions, dependent: :destroy
+  has_many :import_distribution_transitions, autosave: false, dependent: :destroy
+
+  # Validations
+  validates :csv_file, attached: true, content_type: {in: "text/csv", message: "is not a CSV file"}
+
+  validates_with ImportDistribution::CsvHeaderValidator
+
+  # States
+  include Statesman::Adapters::ActiveRecordQueries[
+    transition_class: ImportDistributionTransition,
+    initial_state: :created
+  ]
+
+  def state_machine
+    @state_machine ||= ImportDistributionStateMachine.new(self, transition_class: ImportDistributionTransition)
+  end
+
+  def set_csv_file_attributes
+    parsed = CSV.parse(csv_file.download)
+
+    update_columns(
+      headers: parsed[0],
+      row_count: parsed.size - 1,
+      content_type: csv_file.content_type.to_s,
+      filename: csv_file.filename.to_s,
+      extension: csv_file.filename.extension.to_s
+    )
+  end
+
+  def run!
+    # @TODO: guard this call, unless mappings_valid?
+
+    # Queue Job
+    ImportDistributionsRunJob.perform_later(self)
+
+    # Capture State
+    state_machine.transition_to!(:imported)
+    save
+  end
+end

--- a/app/models/import_distribution/csv_header_validator.rb
+++ b/app/models/import_distribution/csv_header_validator.rb
@@ -7,6 +7,11 @@ class ImportDistribution
   # CsvHeaderValidator
   class CsvHeaderValidator < ActiveModel::Validator
     def validate(record)
+      if record.csv_file.nil?
+        record.errors.add(:csv_file, "Missing a required CSV header. friendlier_id, reference_type, distribution_url, and label are required.")
+        return false
+      end
+
       valid_csv_header = true
       unless valid_csv_headers?(record&.csv_file)
         valid_csv_header = false

--- a/app/models/import_distribution/csv_header_validator.rb
+++ b/app/models/import_distribution/csv_header_validator.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "csv"
+
+# CSV Header Validation
+class ImportDistribution
+  # CsvHeaderValidator
+  class CsvHeaderValidator < ActiveModel::Validator
+    def validate(record)
+      valid_csv_header = true
+      unless valid_csv_headers?(record&.csv_file)
+        valid_csv_header = false
+        record.errors.add(:csv_file,
+          "Missing a required CSV header. friendlier_id, reference_type, distribution_url, and label are required.")
+      end
+
+      valid_csv_header
+    end
+
+    def valid_csv_headers?(csv_file)
+      headers = CSV.parse(csv_file.download)[0]
+      (["friendlier_id", "reference_type", "distribution_url", "label"] - headers).empty?
+    rescue ArgumentError, ActiveStorage::FileNotFoundError
+      false
+    end
+  end
+end

--- a/app/models/import_distribution_state_machine.rb
+++ b/app/models/import_distribution_state_machine.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Import Distribution Statesman
+class ImportDistributionStateMachine
+  include Statesman::Machine
+
+  state :created, initial: true
+  state :mapped
+  state :imported
+  state :success
+  state :failed
+
+  transition from: :created, to: [:mapped]
+  transition from: :mapped, to: [:imported]
+  transition from: :imported, to: %i[success failed]
+end

--- a/app/models/import_distribution_state_machine.rb
+++ b/app/models/import_distribution_state_machine.rb
@@ -5,12 +5,10 @@ class ImportDistributionStateMachine
   include Statesman::Machine
 
   state :created, initial: true
-  state :mapped
   state :imported
   state :success
   state :failed
 
-  transition from: :created, to: [:mapped]
-  transition from: :mapped, to: [:imported]
+  transition from: :created, to: [:imported]
   transition from: :imported, to: %i[success failed]
 end

--- a/app/models/import_distribution_transition.rb
+++ b/app/models/import_distribution_transition.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Add Import Distribution Statesman Transitions
+class ImportDistributionTransition < ApplicationRecord
+  include Statesman::Adapters::ActiveRecordTransition
+
+  # If your transition table doesn't have the default `updated_at` timestamp column,
+  # you'll need to configure the `updated_timestamp_column` option, setting it to
+  # another column name (e.g. `:updated_on`) or `nil`.
+  #
+  # self.updated_timestamp_column = :updated_on
+  # self.updated_timestamp_column = nil
+
+  belongs_to :import_distribution, inverse_of: :import_distribution_transitions
+
+  after_destroy :update_most_recent, if: :most_recent?
+
+  private
+
+  def update_most_recent
+    last_transition = import_distribution.import_distribution_transitions.order(:sort_key).last
+    return if last_transition.blank?
+
+    last_transition.update_column(:most_recent, true)
+  end
+end

--- a/app/models/import_document_distribution.rb
+++ b/app/models/import_document_distribution.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# ImportDocumentDistribution class
+class ImportDocumentDistribution < ApplicationRecord
+  has_many :import_document_distribution_transitions, autosave: false, dependent: :destroy
+
+  include Statesman::Adapters::ActiveRecordQueries[
+    transition_class: ImportDocumentDistributionTransition,
+    initial_state: :queued
+  ]
+
+  def state_machine
+    @state_machine ||= ImportDocumentDistributionStateMachine.new(self, transition_class: ImportDocumentDistributionTransition)
+  end
+
+  def to_hash
+    {
+      friendlier_id: friendlier_id,
+      reference_type: ReferenceType.find_by(name: reference_type),
+      url: distribution_url,
+      label: label,
+      import_distribution_id: import_distribution_id
+    }
+  end
+end

--- a/app/models/import_document_distribution_state_machine.rb
+++ b/app/models/import_document_distribution_state_machine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# ImportDocumentDistribution Statesman
+class ImportDocumentDistributionStateMachine
+  include Statesman::Machine
+
+  state :queued, initial: true
+  state :success
+  state :failed
+
+  transition from: :queued, to: %i[success failed]
+  transition from: :failed, to: :success
+end

--- a/app/models/import_document_distribution_transition.rb
+++ b/app/models/import_document_distribution_transition.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Add ImportDocumentDistribution Statesman Transitions
+class ImportDocumentDistributionTransition < ApplicationRecord
+  include Statesman::Adapters::ActiveRecordTransition
+
+  belongs_to :import_document_distribution, inverse_of: :import_document_distribution_transitions
+
+  after_destroy :update_most_recent, if: :most_recent?
+
+  private
+
+  def update_most_recent
+    last_transition = import_document_distribution.import_document_distribution_transitions.order(:sort_key).last
+    return if last_transition.blank?
+
+    last_transition.update_column(:most_recent, true)
+  end
+end

--- a/app/views/admin/document_distributions/index.html.erb
+++ b/app/views/admin/document_distributions/index.html.erb
@@ -6,12 +6,12 @@
       Document &middot; Distributions
 
       <% if params[:document_id] %>
-        <%= link_to '+ Import CSV', import_admin_document_document_distributions_path(@document), { class: 'btn btn-primary float-right' } %>
+        <%= link_to '+ Import CSV', new_admin_import_distribution_path, { class: 'btn btn-primary float-right' } %>
 
         <%= link_to '+ New Distribution', new_admin_document_document_distribution_path(@document), { class: 'btn btn-primary float-right mr-2' } %>
       <% else %>
         <%= link_to '- Delete CSV', destroy_all_admin_document_distributions_path, { class: 'btn btn-danger float-right' } %>
-        <%= link_to '+ Import CSV', import_admin_document_distributions_path, { class: 'btn btn-primary float-right mr-4' } %>
+        <%= link_to '+ Import CSV', new_admin_import_distribution_path, { class: 'btn btn-primary float-right mr-4' } %>
       <% end %>
     </h1>
 

--- a/app/views/admin/import_distributions/_form.html.erb
+++ b/app/views/admin/import_distributions/_form.html.erb
@@ -1,0 +1,21 @@
+<% if @import_distribution.errors.any? %>
+  <div class="alert alert-danger mb-4" role="alert">
+    <h2 class="h4" class="alert-heading"><%= pluralize(@import_distribution.errors.count, "error") %> prohibited this import distribution from being saved</h2>
+    <ol class="mb-0">
+      <% @import_distribution.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ol>
+  </div>
+<% end %>
+
+<div class="form-inputs">
+  <%= f.input :name, {autofocus: true} %>
+  <%= f.input :source %>
+  <%= f.input :description %>
+  <%= f.file_field :csv_file, direct_upload: true %>
+</div>
+
+<div class="form-actions">
+  <%= f.button :submit, "+ Create Import Distributions", {class: 'btn btn-primary'} %>
+</div>

--- a/app/views/admin/import_distributions/_import_distribution.json.jbuilder
+++ b/app/views/admin/import_distributions/_import_distribution.json.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.extract! import_distribution, :id, :name, :filename, :source, :description, :row_count, :headers, :encoding, :content_type,
+  :extension, :validity, :validation_result, :created_at, :updated_at
+json.url import_distribution_url(import_distribution, format: :json)

--- a/app/views/admin/import_distributions/_show_failed_tab.html.erb
+++ b/app/views/admin/import_distributions/_show_failed_tab.html.erb
@@ -1,0 +1,36 @@
+<h6>
+  <span class='float-left mt-3'>
+    <%== pagy_info(@pagy_failed) %>
+  </span>
+  <span class='float-right'>
+    <%== pagy_bootstrap_nav(@pagy_failed) %>
+  </span>
+</h6>
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>State</th>
+      <th>Title</th>
+      <th>Identifier</th>
+      <th>Reason</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @import_failed_distributions.each_with_index do |distribution, index| %>
+      <tr>
+        <td>
+          <span class="badge badge-danger">
+            <%= distribution.state_machine.current_state %>
+          </span>
+        </td>
+        <td><%= distribution.friendlier_id %></td>
+        <td>
+          <%= link_to admin_import_distribution_path(@import_distribution, distribution) do %>
+            <%= distribution.state_machine&.last_transition&.metadata %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/import_distributions/_show_success_tab.html.erb
+++ b/app/views/admin/import_distributions/_show_success_tab.html.erb
@@ -1,0 +1,35 @@
+<h6>
+  <span class='float-left mt-3'>
+    <%== pagy_info(@pagy_success) %>
+  </span>
+  <span class='float-right'>
+    <%== pagy_bootstrap_nav(@pagy_success) %>
+  </span>
+</h6>
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>State</th>
+      <th>Friendlier ID</th>
+      <th>Distribution URL</th>
+      <th>Reference Type</th>
+      <th>Label</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @import_success_distributions.each_with_index do |distribution, index| %>
+      <tr>
+        <td>
+          <span class="badge badge-success">
+            <%= distribution.state_machine.current_state %>
+          </span>
+        </td>
+        <td><%= distribution.friendlier_id %></td>
+        <td><%= distribution.distribution_url %></td>
+        <td><%= distribution.reference_type %></td>
+        <td><%= distribution.label %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/import_distributions/edit.html.erb
+++ b/app/views/admin/import_distributions/edit.html.erb
@@ -1,0 +1,8 @@
+<h1>Editing Import Distribution</h1>
+
+<%= simple_form_for(@import_distribution, :url => admin_import_distribution_path) do |f| %>
+  <%= render 'form', import_distribution: @import_distribution, f: f %>
+<% end %>
+
+<%= link_to 'Show', admin_import_distribution_path(@import_distribution) %> |
+<%= link_to 'Back', admin_import_distributions_path %>

--- a/app/views/admin/import_distributions/index.html.erb
+++ b/app/views/admin/import_distributions/index.html.erb
@@ -1,10 +1,10 @@
-<%- @page_title = "GBL♦Admin - Imports" %>
+<%- @page_title = "GBL♦Admin - Import Distributions" %>
 
 <div class="row mb-2">
   <div class="col">
     <h1 style="width:100%;">
-      Import Documents
-      <%= link_to '+ New Documents Import', new_admin_import_path, { class: 'btn btn-primary float-right' } %>
+      Import Distributions
+      <%= link_to '+ New Distributions Import', new_admin_import_distribution_path, { class: 'btn btn-primary float-right' } %>
     </h1>
 
     <h6>
@@ -30,17 +30,17 @@
       </thead>
 
       <tbody>
-        <% @imports.each do |import| %>
+        <% @import_distributions.each do |import_distribution| %>
           <tr>
-            <td><%= import.name %></td>
-            <td><%= import.filename %></td>
-            <td><%= import.source %></td>
-            <td><%= import.description %></td>
-            <td><%= import.row_count %></td>
-            <td><%= import.created_at %></td>
-            <td><%= link_to 'Show', admin_import_path(import) %></td>
-            <td><%= link_to 'Edit', edit_admin_import_path(import) %></td>
-            <td><%= link_to 'Destroy', admin_import_path(import), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+            <td><%= import_distribution.name %></td>
+            <td><%= import_distribution.filename %></td>
+            <td><%= import_distribution.source %></td>
+            <td><%= import_distribution.description %></td>
+            <td><%= import_distribution.row_count %></td>
+            <td><%= import_distribution.created_at %></td>
+            <td><%= link_to 'Show', admin_import_distribution_path(import_distribution) %></td>
+            <td><%= link_to 'Edit', edit_admin_import_distribution_path(import_distribution) %></td>
+            <td><%= link_to 'Destroy', admin_import_distribution_path(import_distribution), method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/admin/import_distributions/index.json.jbuilder
+++ b/app/views/admin/import_distributions/index.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @import_distributions, partial: "import_distributions/import_distribution", as: :import_distribution

--- a/app/views/admin/import_distributions/new.html.erb
+++ b/app/views/admin/import_distributions/new.html.erb
@@ -1,0 +1,7 @@
+<h1>New Import Distribution</h1>
+
+<%= simple_form_for(@import_distribution.becomes(ImportDistribution), url: admin_import_distributions_path) do |f| %>
+  <%= render 'form', import_distribution: @import_distribution, f: f %>
+<% end %>
+
+<%= link_to 'Back', admin_import_distributions_path %>

--- a/app/views/admin/import_distributions/show.html.erb
+++ b/app/views/admin/import_distributions/show.html.erb
@@ -47,7 +47,7 @@
   <div class="col-md-3">
     <div class="card">
       <div class="card-header text-center">
-        <h3 class="h5">Imported Documents</h3>
+        <h3 class="h5">Imported Distributions</h3>
       </div>
       <ul class="list-group list-group-flush">
         <li class="list-group-item">

--- a/app/views/admin/import_distributions/show.html.erb
+++ b/app/views/admin/import_distributions/show.html.erb
@@ -51,10 +51,12 @@
       </div>
       <ul class="list-group list-group-flush">
         <li class="list-group-item">
-          <%= form_tag run_admin_import_distribution_path(@import_distribution), method: :patch do -%>
-            <%= hidden_field_tag :run, true -%>
-            <%= submit_tag '+ Run Distribution Import', class: 'btn btn-primary btn-block' -%>
-          <%- end -%>
+          <% if @import_distribution.state_machine.current_state == 'created' %>
+            <%= form_tag run_admin_import_distribution_path(@import_distribution), method: :patch do -%>
+              <%= hidden_field_tag :run, true -%>
+              <%= submit_tag '+ Run Distribution Import', class: 'btn btn-primary btn-block' -%>
+            <%- end -%>
+          <% end %>
           <% if @import_distribution.state_machine.current_state == 'imported' %>
             <table class="table table-sm table-bordered import-documents">
               <thead>
@@ -65,23 +67,19 @@
               </thead>
               <tbody>
               <tr>
-                <td><%= link_to_gbl_import('Published', @import_distribution, 'published') %></td>
-                <td><%= @import_distribution.documents.where(publication_state: 'published').size %></td>
+                <td>Success</td>
+                <td><%= @pagy_success.count %></td>
               </tr>
               <tr>
-                <td><%= link_to_gbl_import('Unpublished', @import_distribution, 'unpublished') %></td>
-                <td><%= @import_distribution.documents.where(publication_state: 'unpublished').size %></td>
-              </tr>
-              <tr>
-                <td><%= link_to_gbl_import('Draft', @import_distribution, 'draft') %></td>
-                <td><%= @import_distribution.documents.where(publication_state: 'draft').size %></td>
+                <td>Failed</td>
+                <td><%= @pagy_failed.count %></td>
               </tr>
               </tbody>
               <tfoot>
                 <tr>
-                  <th><%= link_to_gbl_import('Total', @import_distribution) %></th>
-                  <td><%= @import_distribution.documents.size %></td>
-              </tr>
+                  <th>Total</th>
+                  <td><%= @pagy_success.count + @pagy_failed.count %></td>
+                </tr>
               </tfoot>
             </table>
           <% end %>

--- a/app/views/admin/import_distributions/show.html.erb
+++ b/app/views/admin/import_distributions/show.html.erb
@@ -1,0 +1,123 @@
+<%= link_to 'Edit Import Distribution', edit_admin_import_distribution_path(@import_distribution) %> |
+<%= link_to 'Back', admin_import_distributions_path %>
+
+<div class="row">
+  <div class="col-md-6">
+    <h1>Import Distribution</h1>
+    <p>
+      <strong>Name:</strong>
+      <%= @import_distribution.name %>
+    </p>
+
+    <p>
+      <strong>Filename:</strong>
+      <a href="<%= rails_blob_path(@import_distribution.csv_file, disposition: "attachment")%>">
+        <%= @import_distribution.filename %>
+      </a> (<%= @import_distribution.content_type %>)
+    </p>
+
+    <p>
+      <strong>State:</strong>
+      <%= @import_distribution.state_machine.current_state %>
+    </p>
+
+    <p>
+      <strong>Source:</strong>
+      <%= @import_distribution.source %>
+    </p>
+
+    <p>
+      <strong>Description:</strong>
+      <%= @import_distribution.description %>
+    </p>
+  </div>
+  <div class="col-md-3">
+    <div class="card">
+      <div class="card-header text-center">
+        <h3 class="h5">CSV Row Count</h3>
+      </div>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item text-center">
+          <%= @import_distribution.row_count %>
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="col-md-3">
+    <div class="card">
+      <div class="card-header text-center">
+        <h3 class="h5">Imported Documents</h3>
+      </div>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item">
+          <%= form_tag run_admin_import_distribution_path(@import_distribution), method: :patch do -%>
+            <%= hidden_field_tag :run, true -%>
+            <%= submit_tag '+ Run Distribution Import', class: 'btn btn-primary btn-block' -%>
+          <%- end -%>
+          <% if @import_distribution.state_machine.current_state == 'imported' %>
+            <table class="table table-sm table-bordered import-documents">
+              <thead>
+                <tr>
+                  <th>State</th>
+                  <th>Distribution Count</th>
+                </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td><%= link_to_gbl_import('Published', @import_distribution, 'published') %></td>
+                <td><%= @import_distribution.documents.where(publication_state: 'published').size %></td>
+              </tr>
+              <tr>
+                <td><%= link_to_gbl_import('Unpublished', @import_distribution, 'unpublished') %></td>
+                <td><%= @import_distribution.documents.where(publication_state: 'unpublished').size %></td>
+              </tr>
+              <tr>
+                <td><%= link_to_gbl_import('Draft', @import_distribution, 'draft') %></td>
+                <td><%= @import_distribution.documents.where(publication_state: 'draft').size %></td>
+              </tr>
+              </tbody>
+              <tfoot>
+                <tr>
+                  <th><%= link_to_gbl_import('Total', @import_distribution) %></th>
+                  <td><%= @import_distribution.documents.size %></td>
+              </tr>
+              </tfoot>
+            </table>
+          <% end %>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<nav>
+  <div class="nav nav-tabs" id="import-tabs" role="tablist">
+    <a class="nav-item nav-link <%= @import_distribution.state_machine.current_state == 'imported' ? 'active' : '' %>" id="import-results-tab" data-toggle="tab" href="#import-results" role="tab" aria-controls="import-results"
+      aria-selected="true">Import Results</a>
+  </div>
+</nav>
+
+  <div class="tab-pane fade <%= @import_distribution.state_machine.current_state == 'imported' ? 'show active' : '' %>" id="import-results" role="tabpanel" aria-labelledby="import-results-tab">
+    <h3 class="sr-only">Import Results</h3>
+
+    <br/>
+
+    <nav>
+      <div class="nav nav-tabs" id="import-state-tabs" role="tablist">
+        <a class="nav-item nav-link active" id="import-success-tab" data-toggle="tab" href="#import-state-success" role="tab" aria-controls="import-state-success" aria-selected="true">Success <span class="badge badge-success"><%= @pagy_success.count %></span></a>
+        <a class="nav-item nav-link" id="import-failed-tab" data-toggle="tab" href="#import-state-failed" role="tab" aria-controls="import-state-failed" aria-selected="false">Failed <span class="badge badge-danger"><%= @pagy_failed.count %></span> </a>
+      </div>
+    </nav>
+
+    <div class="tab-content" id="import-states">
+      <div class="tab-pane fade show active" id="import-state-success" role="tabpanel" aria-labelledby="import-state-success-tab">
+        <%= render partial: 'show_success_tab' %>
+      </div>
+
+      <div class="tab-pane fade" id="import-state-failed" role="tabpanel" aria-labelledby="import-state-failed-tab">
+        <%= render partial: 'show_failed_tab' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/import_distributions/show.json.jbuilder
+++ b/app/views/admin/import_distributions/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "import_distributions/import_distribution", import_distribution: @import_distribution

--- a/app/views/admin/shared/_navbar.html.erb
+++ b/app/views/admin/shared/_navbar.html.erb
@@ -46,14 +46,14 @@
         <div class="dropdown-menu" aria-labelledby="navbarDropdown">
           <h6 class="dropdown-header">Data Management</h6>
           <%= link_to "Documents", admin_documents_path, {class: 'dropdown-item'} %>
-          <%= link_to "Imports", admin_imports_path, {class: 'dropdown-item'} %>
+          <%= link_to "Import Documents", admin_imports_path, {class: 'dropdown-item'} %>
+          <%= link_to "Import Distributions", admin_import_distributions_path, {class: 'dropdown-item'} %>
           <%= link_to "Bulk Actions", admin_bulk_actions_path, {class: 'dropdown-item'} %>
           <div class="dropdown-divider"></div>
           <h6 class="dropdown-header">Document Relationships</h6>
           <%= link_to "Access Links", admin_document_accesses_path, {class: 'dropdown-item'} %>
           <%= link_to "Assets", admin_assets_path, {class: 'dropdown-item'} %>
           <%= link_to "Distributions", admin_document_distributions_path, {class: 'dropdown-item'} %>
-          <%= link_to "Download Links", admin_document_downloads_path, {class: 'dropdown-item'} %>
           <div class="dropdown-divider"></div>
           <h6 class="dropdown-header">Business Intelligence</h6>
           <%= link_to "Blazer", '/admin/blazer', {class: 'dropdown-item', data: { turbolinks: false }} %>

--- a/db/migrate/20250113213655_import_distributions.rb
+++ b/db/migrate/20250113213655_import_distributions.rb
@@ -1,0 +1,56 @@
+class ImportDistributions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :document_distributions, :import_distribution_id, :bigint
+    
+    create_table :import_distributions do |t|
+      t.string :name
+      t.string :source
+      t.text :description
+      t.string :filename
+      t.integer :row_count
+      t.text :headers, default: [], array: true
+      t.string :encoding
+      t.string :content_type
+      t.string :extension
+      t.boolean :validity, default: false
+      t.text :validation_result
+
+      t.timestamps
+    end
+
+    create_table :import_distribution_transitions do |t|
+      t.string :to_state, null: false
+      t.text :metadata, default: "{}"
+      t.integer :sort_key, null: false
+      t.integer :import_distribution_id, null: false
+      t.boolean :most_recent, null: false
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+      t.index ["import_distribution_id", "most_recent"], name: "index_import_distribution_transitions_parent_most_recent", unique: true, where: "most_recent"
+      t.index ["import_distribution_id", "sort_key"], name: "index_import_distribution_transitions_parent_sort", unique: true
+    end
+
+    create_table :import_document_distributions do |t|
+      t.string :friendlier_id
+      t.string :reference_type
+      t.text :distribution_url
+      t.string :label
+      t.bigint :import_distribution_id, null: false
+      t.index ["import_distribution_id"], name: "index_import_distributions_on_import_distribution_id"
+
+      t.timestamps
+    end
+
+    create_table :import_document_distribution_transitions do |t|
+      t.string :to_state, null: false
+      t.text :metadata, default: "{}"
+      t.integer :sort_key, null: false
+      t.integer :import_document_distribution_id, null: false
+      t.boolean :most_recent, null: false
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+      t.index ["import_document_distribution_id", "most_recent"], name: "index_import_doc_distribution_transitions_parent_most_recent", unique: true, where: "most_recent"
+      t.index ["import_document_distribution_id", "sort_key"], name: "index_import_doc_distribution_transitions_parent_sort", unique: true
+    end
+  end
+end

--- a/lib/generators/geoblacklight_admin/config_generator.rb
+++ b/lib/generators/geoblacklight_admin/config_generator.rb
@@ -423,6 +423,7 @@ module GeoblacklightAdmin
     # Add test fixture files - Necessary for import background job tests
     def add_test_fixture_files
       copy_file "btaa_sample_records.csv", "test/fixtures/files/btaa_sample_records.csv", force: true
+      copy_file "btaa_sample_document_distributions.csv", "test/fixtures/files/btaa_sample_document_distributions.csv", force: true
     end
 
     # Run bundle with vite install

--- a/lib/generators/geoblacklight_admin/config_generator.rb
+++ b/lib/generators/geoblacklight_admin/config_generator.rb
@@ -129,6 +129,12 @@ module GeoblacklightAdmin
             patch :run, on: :member
           end
 
+          # Import Distributions
+          resources :import_distributions do
+            resources :import_document_distributions, only: [:show]
+            patch :run, on: :member
+          end 
+
           # Elements
           resources :elements do
             post :sort, on: :collection
@@ -221,9 +227,6 @@ module GeoblacklightAdmin
               collection do
                 get "display_attach_form"
                 post "attach_files"
-
-                get "import"
-                post "import"
 
                 get "destroy_all"
                 post "destroy_all"

--- a/lib/generators/geoblacklight_admin/templates/btaa_sample_document_distributions.csv
+++ b/lib/generators/geoblacklight_admin/templates/btaa_sample_document_distributions.csv
@@ -1,0 +1,17 @@
+friendlier_id,reference_type,distribution_url,label
+82784459-acde-42ed-b615-d8300577110e,documentation_external,https://gisdata.mn.gov/dataset/82784459-acde-42ed-b615-d8300577110e,
+82784459-acde-42ed-b615-d8300577110e,download,https://resources.gisdata.mn.gov/pub/gdrs/data/pub/us_mn_state_dnr/water_lake_superior_basin/fgdb_water_lake_superior_basin.zip,Geodatabase
+82784459-acde-42ed-b615-d8300577110e,download,https://resources.gisdata.mn.gov/pub/gdrs/data/pub/us_mn_state_dnr/water_lake_superior_basin/gpkg_water_lake_superior_basin.zip,GeoPackage
+82784459-acde-42ed-b615-d8300577110e,download,https://resources.gisdata.mn.gov/pub/gdrs/data/pub/us_mn_state_dnr/water_lake_superior_basin/shp_water_lake_superior_basin.zip,Shapefile
+82784459-acde-42ed-b615-d8300577110e,full_layer_description,https://gisdata.mn.gov/dataset/82784459-acde-42ed-b615-d8300577110e,Landing Page
+82784459-acde-42ed-b615-d8300577110e,image,https://resources.gisdata.mn.gov/pub/gdrs/data/pub/us_mn_state_dnr/water_lake_superior_basin/metadata/preview.jpg,Static Preview - Sample Image
+82784459-acde-42ed-b615-d8300577110e,metadata_html,https://resources.gisdata.mn.gov/pub/gdrs/data/pub/us_mn_state_dnr/water_lake_superior_basin/metadata/metadata.html,Full Metadata Record
+p16022coll230:1933,documentation_external,https://umedia.lib.umn.edu/item/p16022coll230:1933,
+p16022coll230:1933,iiif_image,https://cdm16022.contentdm.oclc.org/digital/iiif/p16022coll230/1933/info.json,
+p16022coll230:1933,iiif_manifest,https://cdm16022.contentdm.oclc.org/iiif/info/p16022coll230/1933/manifest.json,
+p16022coll230:321,documentation_external,https://umedia.lib.umn.edu/item/p16022coll230:321,
+p16022coll230:321,iiif_image,https://cdm16022.contentdm.oclc.org/digital/iiif/p16022coll230/321/info.json,
+p16022coll230:321,iiif_manifest,https://cdm16022.contentdm.oclc.org/iiif/info/p16022coll230/321/manifest.json,
+p16022coll230:4115,documentation_external,https://umedia.lib.umn.edu/item/p16022coll230:4115,
+p16022coll230:4115,iiif_image,https://cdm16022.contentdm.oclc.org/digital/iiif/p16022coll230/4115/info.json,
+p16022coll230:4115,iiif_manifest,https://cdm16022.contentdm.oclc.org/iiif/info/p16022coll230/4115/manifest.json,

--- a/test/controllers/document_distributions_controller_test.rb
+++ b/test/controllers/document_distributions_controller_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class DocumentReferencesControllerTest < ActionDispatch::IntegrationTest
+class DocumentDistributionsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @document = documents(:ls)
     @document_distribution = document_distributions(:ag_1)
@@ -63,17 +63,5 @@ class DocumentReferencesControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to admin_document_document_distributions_url(@document)
-  end
-
-  test "should import distributions successfully" do
-    post import_admin_document_distributions_url(@document), params: {document_id: @document.friendlier_id, document_distribution: {distributions: {file: @file}}}
-    assert_redirected_to admin_document_document_distributions_path(@document)
-    assert_equal "Distributions were created successfully.", flash[:notice]
-  end
-
-  test "should not import distributions with invalid file" do
-    post import_admin_document_distributions_url(@document), params: {document_id: @document.friendlier_id, document_distribution: {distributions: {file: nil}}}
-    assert_redirected_to admin_document_document_distributions_path(@document)
-    assert_equal "Distributions could not be created. File does not exist or is invalid.", flash[:notice]
   end
 end

--- a/test/controllers/import_distributions_controller_test.rb
+++ b/test/controllers/import_distributions_controller_test.rb
@@ -1,0 +1,60 @@
+require 'test_helper'
+
+class ImportDistributionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:user_001) # Assuming you have a fixture or factory for users
+    sign_in @user
+
+    @import_distribution = import_distributions(:one)
+  end
+
+  test "should get index" do
+    get admin_import_distributions_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_admin_import_distribution_url
+    assert_response :success
+  end
+
+  test "should create import_distribution" do
+    skip("@TODO: add file upload to test")
+    assert_difference('ImportDistribution.count') do
+      post admin_import_distributions_url, params: { import_distribution: { name: 'New Import', filename: 'file.csv' } }
+    end
+
+    assert_redirected_to admin_import_distribution_url(ImportDistribution.last)
+  end
+
+  test "should show import_distribution" do
+    skip("@TODO: add file upload to test")
+    get admin_import_distribution_url(@import_distribution)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_admin_import_distribution_url(@import_distribution)
+    assert_response :success
+  end
+
+  test "should update import_distribution" do
+    skip("@TODO: add file upload to test")
+    patch admin_import_distribution_url(@import_distribution), params: { import_distribution: { name: 'Updated Import' } }
+    assert_redirected_to admin_import_distribution_url(@import_distribution)
+  end
+
+  test "should destroy import_distribution" do
+    assert_difference('ImportDistribution.count', -1) do
+      delete admin_import_distribution_url(@import_distribution)
+    end
+
+    assert_redirected_to admin_import_distributions_url
+  end
+
+  test "should run import_distribution" do
+    skip("@TODO: add file upload to test")
+    post run_admin_import_distribution_url(@import_distribution)
+    assert_redirected_to admin_import_distribution_url(@import_distribution)
+  end
+end

--- a/test/controllers/import_distributions_controller_test.rb
+++ b/test/controllers/import_distributions_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class ImportDistributionsControllerTest < ActionDispatch::IntegrationTest
   setup do
@@ -20,8 +20,8 @@ class ImportDistributionsControllerTest < ActionDispatch::IntegrationTest
 
   test "should create import_distribution" do
     skip("@TODO: add file upload to test")
-    assert_difference('ImportDistribution.count') do
-      post admin_import_distributions_url, params: { import_distribution: { name: 'New Import', filename: 'file.csv' } }
+    assert_difference("ImportDistribution.count") do
+      post admin_import_distributions_url, params: {import_distribution: {name: "New Import", filename: "file.csv"}}
     end
 
     assert_redirected_to admin_import_distribution_url(ImportDistribution.last)
@@ -40,12 +40,12 @@ class ImportDistributionsControllerTest < ActionDispatch::IntegrationTest
 
   test "should update import_distribution" do
     skip("@TODO: add file upload to test")
-    patch admin_import_distribution_url(@import_distribution), params: { import_distribution: { name: 'Updated Import' } }
+    patch admin_import_distribution_url(@import_distribution), params: {import_distribution: {name: "Updated Import"}}
     assert_redirected_to admin_import_distribution_url(@import_distribution)
   end
 
   test "should destroy import_distribution" do
-    assert_difference('ImportDistribution.count', -1) do
+    assert_difference("ImportDistribution.count", -1) do
       delete admin_import_distribution_url(@import_distribution)
     end
 

--- a/test/controllers/import_distributions_controller_test.rb
+++ b/test/controllers/import_distributions_controller_test.rb
@@ -28,7 +28,6 @@ class ImportDistributionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should show import_distribution" do
-    skip("@TODO: add file upload to test")
     get admin_import_distribution_url(@import_distribution)
     assert_response :success
   end

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -4,8 +4,12 @@ one:
   record_id: <%= ActiveRecord::FixtureSet.identify(:one) %>
   blob_id: <%= ActiveRecord::FixtureSet.identify(:csv) %>
 
-
 import_btaa:
   name: 'csv_file'
   record: one (Import)
   blob: import_btaa_blob
+
+import_distribution:
+  name: 'csv_file'
+  record: one (ImportDistribution)
+  blob: import_distribution_blob

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -7,3 +7,4 @@ csv:
   service_name: 'local'
 
 import_btaa_blob: <%= ActiveStorage::FixtureSet.blob filename: "btaa_sample_records.csv", service_name: "test" %>
+import_distribution_blob: <%= ActiveStorage::FixtureSet.blob filename: "btaa_sample_document_distributions.csv", service_name: "test" %>

--- a/test/fixtures/import_distributions.yml
+++ b/test/fixtures/import_distributions.yml
@@ -1,0 +1,33 @@
+one:
+  name: MyString
+  filename: myfile.csv
+  source: MySource
+  description: MyDescription
+  row_count: 100
+  headers:
+  - friendlier_id	
+  - reference_type
+  - distribution_url
+  - label
+  encoding: UTF-8
+  content_type: text/csv
+  extension: csv
+  validity: true
+  validation_result: MyResult
+
+two:
+  name: AnotherString
+  filename: anotherfile.csv
+  source: AnotherSource
+  description: AnotherDescription
+  row_count: 200
+  headers:
+    - friendlier_id	
+    - reference_type
+    - distribution_url
+    - label
+  encoding: UTF-8
+  content_type: text/csv
+  extension: csv
+  validity: true
+  validation_result: AnotherResult

--- a/test/jobs/import_distributions_run_job_test.rb
+++ b/test/jobs/import_distributions_run_job_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ImportDistributionsRunJobTest < ActiveJob::TestCase
+  setup do
+    @import_distribution = import_distributions(:one)
+
+    @import_distribution.csv_file = ActiveStorage::Blob.find_signed(active_storage_blobs(:import_distribution_blob).signed_id)
+  end
+
+  test "should create ImportDocuments for each CSV row" do
+    # Perform the job
+    perform_enqueued_jobs do
+      ImportDistributionsRunJob.perform_now(@import_distribution)
+    end
+
+    assert_equal 16, ImportDocumentDistribution.count
+    assert ImportDocumentDistribution.exists?(friendlier_id: "p16022coll230:4115")
+  end
+
+  test "should handle CSV parsing errors gracefully" do
+    # Adjust the CSV content to simulate an error
+    @import_distribution.csv_file.define_singleton_method(:download) { "title,id\nInvalid row" }
+
+    # Perform the job with the erroneous content
+    assert_nothing_raised do
+      perform_enqueued_jobs do
+        ImportDistributionsRunJob.perform_now(@import_distribution)
+      end
+    end
+
+    # Ensure no new ImportDocuments were created (1 already exists from fixture)
+    assert_equal 1, ImportDocumentDistribution.count
+  end
+
+  test "logs errors without stopping the job" do
+    skip("TODO: these all error because they need the btaa_sample_records.csv file to be imported first")
+    # Stub convert_data to raise an error
+    def @import_distribution.convert_data(_)
+      raise "Simulated error"
+    end
+
+    # Perform the job and check that it handles the error
+    assert_nothing_raised do
+      perform_enqueued_jobs do
+        ImportDistributionsRunJob.perform_now(@import_distribution)
+      end
+    end
+
+    # No new ImportDocumentDistributions should be created due to the error (1 already exists from fixture)
+    assert_equal 1, ImportDocumentDistribution.count
+  end
+end

--- a/test/models/document_distribution_test.rb
+++ b/test/models/document_distribution_test.rb
@@ -53,14 +53,6 @@ class DocumentDistributionTest < ActiveSupport::TestCase
     assert_equal expected_aardvark, @document_distribution.to_aardvark_distribution
   end
 
-  test "should import from CSV" do
-    file_path = File.expand_path("../../../test/fixtures/files/import_distributions.csv", __FILE__)
-    file = File.open(file_path)
-    assert_difference "DocumentDistribution.count", 3 do
-      DocumentDistribution.import(file)
-    end
-  end
-
   test "should destroy all from CSV" do
     file_path = File.expand_path("../../../test/fixtures/files/import_distributions.csv", __FILE__)
     file = File.open(file_path)

--- a/test/models/import_distribution/csv_header_validator_test.rb
+++ b/test/models/import_distribution/csv_header_validator_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ImportDistribution::CsvHeaderValidatorTest < ActiveSupport::TestCase
+  def setup
+    @validator = ImportDistribution::CsvHeaderValidator.new
+    @record = OpenStruct.new(csv_file: nil, errors: ActiveModel::Errors.new(self))
+  end
+
+  def test_valid_csv_headers
+    csv_content = "friendlier_id,reference_type,distribution_url,label\n"
+    file_mock = Minitest::Mock.new
+    file_mock.expect :download, StringIO.new(csv_content)
+    file_mock.expect :nil?, false
+    @record.csv_file = file_mock
+    
+    assert @validator.validate(@record), "Expected CSV headers to be valid"
+    assert_empty @record.errors[:csv_file], "Expected no errors for valid CSV headers"
+  end
+
+  def test_invalid_csv_headers
+    csv_content = "friendlier_id,reference_type\n"
+    file_mock = Minitest::Mock.new
+    file_mock.expect :download, StringIO.new(csv_content)
+    file_mock.expect :nil?, false
+    @record.csv_file = file_mock
+    
+    refute @validator.validate(@record), "Expected CSV headers to be invalid"
+    assert_includes @record.errors[:csv_file], "Missing a required CSV header. friendlier_id, reference_type, distribution_url, and label are required."
+  end
+
+  def test_missing_csv_file
+    @record.csv_file = nil
+    
+    refute @validator.validate(@record), "Expected validation to fail with missing CSV file"
+    assert_includes @record.errors[:csv_file], "Missing a required CSV header. friendlier_id, reference_type, distribution_url, and label are required."
+  end
+end

--- a/test/models/import_distribution/csv_header_validator_test.rb
+++ b/test/models/import_distribution/csv_header_validator_test.rb
@@ -14,7 +14,7 @@ class ImportDistribution::CsvHeaderValidatorTest < ActiveSupport::TestCase
     file_mock.expect :download, StringIO.new(csv_content)
     file_mock.expect :nil?, false
     @record.csv_file = file_mock
-    
+
     assert @validator.validate(@record), "Expected CSV headers to be valid"
     assert_empty @record.errors[:csv_file], "Expected no errors for valid CSV headers"
   end
@@ -25,14 +25,14 @@ class ImportDistribution::CsvHeaderValidatorTest < ActiveSupport::TestCase
     file_mock.expect :download, StringIO.new(csv_content)
     file_mock.expect :nil?, false
     @record.csv_file = file_mock
-    
+
     refute @validator.validate(@record), "Expected CSV headers to be invalid"
     assert_includes @record.errors[:csv_file], "Missing a required CSV header. friendlier_id, reference_type, distribution_url, and label are required."
   end
 
   def test_missing_csv_file
     @record.csv_file = nil
-    
+
     refute @validator.validate(@record), "Expected validation to fail with missing CSV file"
     assert_includes @record.errors[:csv_file], "Missing a required CSV header. friendlier_id, reference_type, distribution_url, and label are required."
   end

--- a/test/models/import_distribution_state_machine_test.rb
+++ b/test/models/import_distribution_state_machine_test.rb
@@ -4,6 +4,6 @@ require "test_helper"
 
 class ImportDistributionStateMachineTest < ActiveSupport::TestCase
   test "states" do
-    assert_equal(ImportDistributionStateMachine.states, %w[created mapped imported success failed])
+    assert_equal(ImportDistributionStateMachine.states, %w[created imported success failed])
   end
 end

--- a/test/models/import_distribution_state_machine_test.rb
+++ b/test/models/import_distribution_state_machine_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ImportDistributionStateMachineTest < ActiveSupport::TestCase
+  test "states" do
+    assert_equal(ImportDistributionStateMachine.states, %w[created mapped imported success failed])
+  end
+end

--- a/test/models/import_document_distribution_state_machine_test.rb
+++ b/test/models/import_document_distribution_state_machine_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ImportDocumentDistributionStateMachineTest < ActiveSupport::TestCase
+  test "states" do
+    assert_equal(ImportDocumentDistributionStateMachine.states, %w[queued success failed])
+  end
+end

--- a/test/system/imports_test.rb
+++ b/test/system/imports_test.rb
@@ -10,7 +10,7 @@ class ImportsTest < ApplicationSystemTestCase
 
   test "visiting the index" do
     visit admin_imports_url
-    assert_selector "h1", text: "Imports"
+    assert_selector "h1", text: "Import Documents"
   end
 
   test "creating a Import" do

--- a/test/system/navigation_test.rb
+++ b/test/system/navigation_test.rb
@@ -15,12 +15,17 @@ class NavigationTest < ApplicationSystemTestCase
       assert page.has_selector?("input[name='q']")
       assert page.has_link?("Admin Tools")
       assert page.has_link?("Documents", visible: false)
-      assert page.has_link?("Imports", visible: false)
-      assert page.has_link?("Access Links", visible: false)
+      assert page.has_link?("Import Documents", visible: false)
+      assert page.has_link?("Import Distributions", visible: false)
       assert page.has_link?("Bulk Actions", visible: false)
+      assert page.has_link?("Access Links", visible: false)
+      assert page.has_link?("Assets", visible: false)
+      assert page.has_link?("Distributions", visible: false)
+      assert page.has_link?("Blazer", visible: false)
+      assert page.has_link?("Elements", visible: false)
+      assert page.has_link?("Form Elements", visible: false)
+      assert page.has_link?("Reference Types", visible: false)
       assert page.has_link?("Users", visible: false)
-      assert page.has_link?("Bookmarks", visible: false)
-      assert page.has_link?("Sign Out", visible: false)
     end
   end
 end


### PR DESCRIPTION
This PR moves the distribution import from inline to the background, to ensure large distribution files can be processed without server timeouts.

Fixes #137 

